### PR TITLE
Optimize Makefile:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MKDIR = mkdir
 DIR_BUILD = .build
 prefix = /usr/local
 
-PPFLAGS = -MT $@ -MMD -MP -MF $(DIR_BUILD)/$*.d -D_POSIX_C_SOURCE=200809L
+PPFLAGS = -MT $@ -MMD -MP -MF $(patsubst %.o, %.d, $@) -D_POSIX_C_SOURCE=200809L
 
 CFLAGS_LOCAL = -Wall -g -std=c99 -coverage
 CFLAGS_LOCAL += $(CFLAGS)


### PR DESCRIPTION
  1.  Using automatic variable instead of $(DIR_BUILD) in dependency file output.